### PR TITLE
Variation cluster annotations

### DIFF
--- a/all_steps.merge_and_annotate_loci.log
+++ b/all_steps.merge_and_annotate_loci.log
@@ -7,8 +7,10 @@
 + GENCODE_GTF_PATH=/Users/weisburd/code/str-truth-set/ref/other/gencode.v46.basic.annotation.gtf.gz
 + '[' '!' -f /Users/weisburd/project1/ref/GRCh38/hg38.fa ']'
 + '[' '!' -f /Users/weisburd/code/str-truth-set/ref/other/gencode.v46.basic.annotation.gtf.gz ']'
-+ mkdir -p results
-+ cd results
+++ date +%F
++ OUTPUT_DIR=results__2024-08-04
++ mkdir -p results__2024-08-04
++ cd results__2024-08-04
 + SECONDS=0
 + KNOWN_DISEASE_ASSOCIATED_LOCI_URL=https://raw.githubusercontent.com/broadinstitute/str-analysis/main/str_analysis/variant_catalogs/variant_catalog_without_offtargets.GRCh38.json
 + ILLUMINA_CATALOG_URL=https://storage.googleapis.com/str-truth-set/hg38/ref/other/illumina_variant_catalog.sorted.bed.gz
@@ -440,7 +442,7 @@ Stats for combined.51_samples.positive_loci.filtered.json:
       552,755 out of    552,755 (100.0%) repeat interval size is an integer multiple of the motif size (aka. trimmed)
             0 out of    552,755 (  0.0%) repeat intervals are homopolymers
       118,307 out of    552,755 ( 21.4%) repeat intervals overlap each other by at least two motif lengths
-Examples of overlapping repeats: chr2:54201636-54201700, chr3:124495965-124496013, chr16:7894531-7894555, chr9:34875950-34875986, chr8:30620239-30620257, chr5:22343321-22343363, chr18:61528446-61528482, chr11:36769230-36769270, chr21:20501007-20501039, chr1:166109878-166109890
+Examples of overlapping repeats: chr7:26139236-26139270, chr18:40865534-40865572, chr21:28831518-28831566, chr4:81620111-81620143, chr11:7856041-7856085, chr4:135734229-135734247, chr9:119497356-119497378, chr11:75930927-75930987, chr19:19605416-19605464, chr4:184895915-184895933
 
 Ranges:
    Motif size range: 2-833bp
@@ -581,6 +583,8 @@ Args:
    mappability_track_bigwig =     gs://tgg-viewer/ref/GRCh38/mappability/GRCh38_no_alt_analysis_set_GCA_000001405.15-k36_m2.bw
    variant_catalog_json_or_bed =  repeat_catalog.3x_and_9bp.hg38.merged.json.gz
    known_disease_associated_loci =  ~/code/str-analysis/str_analysis/variant_catalogs/variant_catalog_without_offtargets.GRCh38.json
+/usr/local/lib/python3.9/site-packages/hailtop/aiocloud/aiogoogle/user_config.py:28: UserWarning: You have specified the GCS requester pays configuration in both your spark-defaults.conf (/usr/local/lib/python3.9/site-packages/pyspark/conf/spark-defaults.conf) and either an explicit argument or through `hailctl config`. For GCS requester pays configuration, Hail first checks explicit arguments, then `hailctl config`, then spark-defaults.conf.
+  warnings.warn(
 Parsing repeat_catalog.3x_and_9bp.hg38.merged.json.gz
 Parsing /Users/weisburd/code/str-truth-set/ref/other/gencode.v46.basic.annotation.gtf.gz...
 Adding gtf records to IntervalTree for overlap detection...
@@ -595,11 +599,29 @@ Wrote 3,227,828 records to /Users/weisburd/code/tandem-repeat-catalogs/repeat_ca
 Filter stats:
  3,227,846 total input rows
  3,227,828 out of 3,227,846 (100%)  passed all filters
++ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz temp.json.gz
++ gunzip -c temp.json.gz
++ sed 's/variant_catalog_without_offtargets.GRCh38.split.filtered.json/known disease-associated loci/'
++ gzip -c -
++ mv temp2.json.gz temp.json.gz
++ gunzip -c temp.json.gz
++ sed 's/illumina_variant_catalog.sorted.filtered.json/Illumina catalog of 174k polymorphic loci/'
++ gzip -c -
++ mv temp2.json.gz temp.json.gz
++ gunzip -c temp.json.gz
++ sed 's/hg38_repeats.motifs_1_to_1000bp.repeats_3x_and_spans_9bp.filtered.json/perfect repeats in hg38/'
++ gzip -c -
++ mv temp2.json.gz temp.json.gz
++ gunzip -c temp.json.gz
++ sed 's/combined.51_samples.positive_loci.filtered.json/polymorphic TR loci in HPRC assemblies/'
++ gzip -c -
++ mv temp2.json.gz temp.json.gz
++ mv temp.json.gz /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz
 + python3 -m str_analysis.convert_expansion_hunter_variant_catalog_to_bed --split-adjacent-repeats /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz --output-file /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.bed.gz
 + python3 -m str_analysis.convert_expansion_hunter_variant_catalog_to_trgt_catalog --split-adjacent-repeats /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz --output-file /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.TRGT.bed
 + python3 -m str_analysis.convert_expansion_hunter_variant_catalog_to_longtr_format /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz --output-file /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.LongTR.bed
-+ wait
 + python3 -m str_analysis.convert_expansion_hunter_variant_catalog_to_hipstr_format /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz --output-file /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.HipSTR.bed
++ wait
 + python3 -m str_analysis.convert_expansion_hunter_variant_catalog_to_gangstr_spec /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz --output-file /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.GangSTR.bed
 Parsing /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz
 Wrote out /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.GangSTR.bed
@@ -629,23 +651,23 @@ chr4	41745972	41746032	ID=PHOX2B;MOTIFS=GCN;STRUC=(GCN)n
 + grep '	80147139	' /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.TRGT.bed
 chr17	80147059	80147139	ID=EIF4A3;MOTIFS=CCTCGCTGTGCCGCTGCCGA;STRUC=(CCTCGCTGTGCCGCTGCCGA)n
 ++ date +%Y-%m-%d
-+ timestamp=2024-08-01
-+ release_draft_folder=release_draft_2024-08-01
-+ mkdir -p release_draft_2024-08-01
++ timestamp=2024-08-04
++ release_draft_folder=release_draft_2024-08-04
++ mkdir -p release_draft_2024-08-04
 + for path in '${OUTPUT_PREFIX}.bed.gz' '${OUTPUT_PREFIX}.bed.gz.tbi' '${OUTPUT_PREFIX}.merged_and_annotated.json.gz' '${OUTPUT_PREFIX}.TRGT.bed' '${OUTPUT_PREFIX}.LongTR.bed' '${OUTPUT_PREFIX}.HipSTR.bed' '${OUTPUT_PREFIX}.GangSTR.bed'
-+ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.bed.gz release_draft_2024-08-01/
++ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.bed.gz release_draft_2024-08-04/
 + for path in '${OUTPUT_PREFIX}.bed.gz' '${OUTPUT_PREFIX}.bed.gz.tbi' '${OUTPUT_PREFIX}.merged_and_annotated.json.gz' '${OUTPUT_PREFIX}.TRGT.bed' '${OUTPUT_PREFIX}.LongTR.bed' '${OUTPUT_PREFIX}.HipSTR.bed' '${OUTPUT_PREFIX}.GangSTR.bed'
-+ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.bed.gz.tbi release_draft_2024-08-01/
++ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.bed.gz.tbi release_draft_2024-08-04/
 + for path in '${OUTPUT_PREFIX}.bed.gz' '${OUTPUT_PREFIX}.bed.gz.tbi' '${OUTPUT_PREFIX}.merged_and_annotated.json.gz' '${OUTPUT_PREFIX}.TRGT.bed' '${OUTPUT_PREFIX}.LongTR.bed' '${OUTPUT_PREFIX}.HipSTR.bed' '${OUTPUT_PREFIX}.GangSTR.bed'
-+ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz release_draft_2024-08-01/
++ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz release_draft_2024-08-04/
 + for path in '${OUTPUT_PREFIX}.bed.gz' '${OUTPUT_PREFIX}.bed.gz.tbi' '${OUTPUT_PREFIX}.merged_and_annotated.json.gz' '${OUTPUT_PREFIX}.TRGT.bed' '${OUTPUT_PREFIX}.LongTR.bed' '${OUTPUT_PREFIX}.HipSTR.bed' '${OUTPUT_PREFIX}.GangSTR.bed'
-+ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.TRGT.bed release_draft_2024-08-01/
++ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.TRGT.bed release_draft_2024-08-04/
 + for path in '${OUTPUT_PREFIX}.bed.gz' '${OUTPUT_PREFIX}.bed.gz.tbi' '${OUTPUT_PREFIX}.merged_and_annotated.json.gz' '${OUTPUT_PREFIX}.TRGT.bed' '${OUTPUT_PREFIX}.LongTR.bed' '${OUTPUT_PREFIX}.HipSTR.bed' '${OUTPUT_PREFIX}.GangSTR.bed'
-+ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.LongTR.bed release_draft_2024-08-01/
++ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.LongTR.bed release_draft_2024-08-04/
 + for path in '${OUTPUT_PREFIX}.bed.gz' '${OUTPUT_PREFIX}.bed.gz.tbi' '${OUTPUT_PREFIX}.merged_and_annotated.json.gz' '${OUTPUT_PREFIX}.TRGT.bed' '${OUTPUT_PREFIX}.LongTR.bed' '${OUTPUT_PREFIX}.HipSTR.bed' '${OUTPUT_PREFIX}.GangSTR.bed'
-+ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.HipSTR.bed release_draft_2024-08-01/
++ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.HipSTR.bed release_draft_2024-08-04/
 + for path in '${OUTPUT_PREFIX}.bed.gz' '${OUTPUT_PREFIX}.bed.gz.tbi' '${OUTPUT_PREFIX}.merged_and_annotated.json.gz' '${OUTPUT_PREFIX}.TRGT.bed' '${OUTPUT_PREFIX}.LongTR.bed' '${OUTPUT_PREFIX}.HipSTR.bed' '${OUTPUT_PREFIX}.GangSTR.bed'
-+ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.GangSTR.bed release_draft_2024-08-01/
++ cp /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.GangSTR.bed release_draft_2024-08-04/
 + python3 -m str_analysis.compute_catalog_stats --verbose /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz
 --------------------------------------------------
 Parsing /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz
@@ -659,7 +681,7 @@ Stats for repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated
             0 out of  3,227,828 (  0.0%) repeat intervals are homopolymers
        17,061 out of  3,227,828 (  0.5%) repeat intervals overlap each other by at least two motif lengths
            11 out of  3,227,828 (  0.0%) repeat intervals have non-ACGT motifs
-Examples of overlapping repeats: chr12:47354714-47354726, chr11:1543057-1543066, chr15:58276212-58276239, chr5:67345051-67345071, chr5:86960885-86960921, chr7:145020235-145020267, chrX:87717009-87717048, chr6:1827076-1827124, chr2:66602257-66602281, chr17:35469321-35469339
+Examples of overlapping repeats: chr7:152922271-152922280, chr2:105950180-105950200, chr2:114110523-114110539, chr7:82186243-82186255, chr17:66798554-66798691, chr5:110587659-110587691, chr19:58410681-58410713, chr8:79210420-79210464, chrX:71964011-71964024, chr6:135232458-135232494
 
 Ranges:
    Motif size range: 2-833bp
@@ -730,20 +752,174 @@ Mappability distribution:
 Wrote 1 rows to repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.catalog_stats.tsv
 + mkdir -p comparisons
 + cd comparisons
++ wget -qnc https://zenodo.org/records/13178746/files/human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.bed.gz
 + wget -qnc https://s3.amazonaws.com/gangstr/hg38/genomewide/hg38_ver17.bed.gz
 + wget -qnc https://storage.googleapis.com/str-truth-set/hg38/ref/other/adotto_tr_catalog_v1.2.bed.gz
 + wget -qnc https://storage.googleapis.com/str-truth-set/hg38/ref/other/mukamel_VNTR_catalog.bed.gz
 + wget -qnc https://storage.googleapis.com/str-truth-set/hg38/ref/other/vamos_catalog.v2.1.bed.gz
++ python3 -u -m str_analysis.convert_trgt_catalog_to_expansion_hunter_catalog -r /Users/weisburd/project1/ref/GRCh38/hg38.fa human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.bed.gz -o human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz
+Parsing human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.bed.gz
+WARNING: MOTIFS ('AAGGG', 'ACAGG') != motifs in locus structure () in row #1883473: ['chr4', '39348425', '39348483', 'ID=CANVAS_RFC1_pathogenic;MOTIFS=AAGGG,ACAGG;STRUC=<RFC1>']
+Writing 7,369,508 records to human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz
+Stats:
+ 7,722,729 loci total input loci
+   406,817 loci skipped
+Wrote 7,369,508 records to human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz
 + python3 -u -m str_analysis.convert_gangstr_spec_to_expansion_hunter_variant_catalog --verbose hg38_ver17.bed.gz
 Parsing hg38_ver17.bed.gz
 Writing records to hg38_ver17.variant_catalog.json
 Stats: {'total input loci': 1340266, 'trimmed locus': 1340266}
 Wrote 1,340,266 records to hg38_ver17.variant_catalog.json
-+ for catalog_filename in mukamel_VNTR_catalog.bed.gz vamos_catalog.v2.1.bed.gz hg38_ver17.variant_catalog.json adotto_tr_catalog_v1.2.bed.gz
++ for catalog_filename in human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz mukamel_VNTR_catalog.bed.gz vamos_catalog.v2.1.bed.gz hg38_ver17.variant_catalog.json adotto_tr_catalog_v1.2.bed.gz
++ echo Processing human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz
+Processing human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz
+++ echo human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz
+++ sed 's/.bed.gz$//'
+++ sed 's/.variant_catalog.json$//'
++ current_catalog_output_prefix=human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz
++ python3 -m str_analysis.annotate_and_filter_str_catalog -r /Users/weisburd/project1/ref/GRCh38/hg38.fa --skip-gene-annotations --skip-mappability-annotations --skip-disease-loci-annotations --min-motif-size 2 --max-motif-size 1000 --output-path human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.annotated_and_filtered.json --verbose human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz
+Args:
+   reference_fasta =              /Users/weisburd/project1/ref/GRCh38/hg38.fa
+   max_motif_size =               1000
+   min_motif_size =               2
+   output_tsv =                   False
+   output_bed =                   False
+   output_stats =                 False
+   show_progress_bar =            False
+   add_gene_region_to_locus_id =  False
+   add_canonical_motif_to_locus_id =  False
+   only_known_disease_associated_loci =  False
+   exclude_known_disease_associated_loci =  False
+   only_known_disease_associated_motifs =  False
+   discard_overlapping_intervals_with_similar_motifs =  False
+   discard_loci_with_non_ACGT_bases_in_motif =  False
+   discard_loci_with_non_ACGTN_bases_in_motif =  False
+   discard_loci_with_non_ACGT_bases_in_reference =  False
+   discard_loci_with_non_ACGTN_bases_in_reference =  False
+   dont_simplify_motifs =         False
+   verbose =                      True
+   skip_gene_annotations =        True
+   skip_disease_loci_annotations =  True
+   skip_mappability_annotations =  True
+   mappability_track_bigwig =     gs://tgg-viewer/ref/GRCh38/mappability/GRCh38_no_alt_analysis_set_GCA_000001405.15-k36_m2.bw
+   variant_catalog_json_or_bed =  human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz
+   output_path =                  human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.annotated_and_filtered.json
+   known_disease_associated_loci =  ~/code/str-analysis/str_analysis/variant_catalogs/variant_catalog_without_offtargets.GRCh38.json
+   genes_gtf =                    ~/code/str-truth-set/ref/other/MANE.v1.0.ensembl_genomic.sorted.gtf.gz
+Parsing human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz
+Wrote 6,355,987 records to human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.annotated_and_filtered.json
+
+Filter stats:
+ 7,369,508 total input rows
+ 6,355,987 out of 7,369,508 (86%)  passed all filters
+ 1,013,521 out of 7,369,508 (14%)  motif size(s) < 2
+
+Modification stats:
+        39 out of 7,369,508 ( 0%)  replaced 8bp motif with a simplified 4bp motif
+        15 out of 7,369,508 ( 0%)  replaced 6bp motif with a simplified 3bp motif
+         9 out of 7,369,508 ( 0%)  replaced 10bp motif with a simplified 5bp motif
+         6 out of 7,369,508 ( 0%)  replaced 9bp motif with a simplified 3bp motif
+         4 out of 7,369,508 ( 0%)  replaced 6bp motif with a simplified 2bp motif
+         2 out of 7,369,508 ( 0%)  replaced 4bp motif with a simplified 2bp motif
+         2 out of 7,369,508 ( 0%)  replaced 12bp motif with a simplified 6bp motif
++ python3 -m str_analysis.compute_catalog_stats --verbose human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.annotated_and_filtered.json
+--------------------------------------------------
+Parsing human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.annotated_and_filtered.json
+
+Stats for human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.annotated_and_filtered.json:
+    6,355,987 total loci
+   133,965,687 base pairs spanned by all loci (4.338% of the genome)
+            0 out of  6,355,987 (  0.0%) loci define adjacent repeats
+    6,355,987 total repeat intervals
+    2,296,255 out of  6,355,987 ( 36.1%) repeat interval size is an integer multiple of the motif size (aka. trimmed)
+            0 out of  6,355,987 (  0.0%) repeat intervals are homopolymers
+            0 out of  6,355,987 (  0.0%) repeat intervals overlap each other by at least two motif lengths
+           14 out of  6,355,987 (  0.0%) repeat intervals have non-ACGT motifs
+
+Ranges:
+   Motif size range: 2-822bp
+   Locus size range: 4-9545bp
+   Num repeats range: 1-2659x repeats
+
+   Maximum locus size = 9545bp               @ chr21:13122210-13131755 (TATGTGAGGGACAAACACTCAGAACCCAGCAGCAGTGTTCTGGAATCC)
+   Minimum fraction pure bases = 0.00      @ chrY:26588581-26588598 (CTGAA)
+   Minimum fraction pure repeats = 0.00    @ chrM:11051-11074 (TACAAATCTCCC)
+
+          chrX:    328,981 out of  6,355,987 (  5.2%) repeat intervals
+          chrY:     47,192 out of  6,355,987 (  0.7%) repeat intervals
+          chrM:         29 out of  6,355,987 (  0.0%) repeat intervals
+   alt contigs:          0 out of  6,355,987 (  0.0%) repeat intervals
+
+Motif size distribution:
+          1bp:          0 out of  6,355,987 (  0.0%) repeat intervals
+          2bp:    371,948 out of  6,355,987 (  5.9%) repeat intervals
+          3bp:    494,549 out of  6,355,987 (  7.8%) repeat intervals
+          4bp:  1,329,380 out of  6,355,987 ( 20.9%) repeat intervals
+          5bp:  1,238,559 out of  6,355,987 ( 19.5%) repeat intervals
+          6bp:  1,324,299 out of  6,355,987 ( 20.8%) repeat intervals
+       7-24bp:  1,564,363 out of  6,355,987 ( 24.6%) repeat intervals
+        25+bp:     32,889 out of  6,355,987 (  0.5%) repeat intervals
+
+Num repeats in reference:
+           1x:    154,248 out of  6,355,987 (  2.4%) repeat intervals
+           2x:  4,015,781 out of  6,355,987 ( 63.2%) repeat intervals
+           3x:    770,522 out of  6,355,987 ( 12.1%) repeat intervals
+           4x:    267,147 out of  6,355,987 (  4.2%) repeat intervals
+           5x:    243,872 out of  6,355,987 (  3.8%) repeat intervals
+           6x:    145,963 out of  6,355,987 (  2.3%) repeat intervals
+           7x:    117,710 out of  6,355,987 (  1.9%) repeat intervals
+           8x:     84,080 out of  6,355,987 (  1.3%) repeat intervals
+           9x:     68,891 out of  6,355,987 (  1.1%) repeat intervals
+       10-15x:    253,820 out of  6,355,987 (  4.0%) repeat intervals
+       16-25x:    147,012 out of  6,355,987 (  2.3%) repeat intervals
+       26-35x:     39,929 out of  6,355,987 (  0.6%) repeat intervals
+       36-50x:     21,497 out of  6,355,987 (  0.3%) repeat intervals
+         51+x:     25,515 out of  6,355,987 (  0.4%) repeat intervals
+
+Fraction pure bases distribution:
+          0.0:    264,542 out of  6,355,987 (  4.2%) repeat intervals
+          0.1:    124,804 out of  6,355,987 (  2.0%) repeat intervals
+          0.2:    160,986 out of  6,355,987 (  2.5%) repeat intervals
+          0.3:    176,220 out of  6,355,987 (  2.8%) repeat intervals
+          0.4:     98,120 out of  6,355,987 (  1.5%) repeat intervals
+          0.5:    913,314 out of  6,355,987 ( 14.4%) repeat intervals
+          0.6:    394,589 out of  6,355,987 (  6.2%) repeat intervals
+          0.7:    136,353 out of  6,355,987 (  2.1%) repeat intervals
+          0.8:    109,996 out of  6,355,987 (  1.7%) repeat intervals
+          0.9:     20,946 out of  6,355,987 (  0.3%) repeat intervals
+          1.0:  3,956,117 out of  6,355,987 ( 62.2%) repeat intervals
+Wrote 1 rows to human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.annotated_and_filtered.catalog_stats.tsv
++ python3 -u -m str_analysis.merge_loci --verbose --output-prefix human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz --write-bed-files-with-new-loci /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.annotated_and_filtered.json
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Parsing /Users/weisburd/code/tandem-repeat-catalogs/repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz
+Added 3,227,828 out of 3,227,828 (100.0%) records from repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz to the output catalog
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+Parsing human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.annotated_and_filtered.json
+Added 5,151,246 out of 6,355,987 ( 81.0%) records from human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.annotated_and_filtered.json to the output catalog
+    Discarded 1,167,868 out of 6,355,987 ( 18.4%) records since they overlapped an exising locus by at least 66.0% and had the exact same LocusStructure
+    Discarded  36,873 out of 6,355,987 (  0.6%) records since they overlapped an existing locus by at least 66.0% and had the same canonical motif
+Wrote 5,151,246 unique loci from human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.annotated_and_filtered.json to human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.annotated_and_filtered.unique_loci.bed.gz
+Writing combined catalog to human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.json.gz
+Done writing 8,379,074 output records to human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.json.gz
+Writing combined catalog to human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.bed
+Done writing 8,379,074 output records to human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz.bed.gz
+Motif sizes:
+   1,641,996 out of 8,379,074 (19.6%) 7+bp
+   1,616,456 out of 8,379,074 (19.3%) 4bp
+   1,440,424 out of 8,379,074 (17.2%) 3bp
+   1,356,900 out of 8,379,074 (16.2%) 6bp
+   1,334,958 out of 8,379,074 (15.9%) 5bp
+     988,340 out of 8,379,074 (11.8%) 2bp
+Chromsomes:
+   7,876,295 out of 8,379,074 (94.0%) are on autosomes
+     435,255 out of 8,379,074 ( 5.2%) are on X
+      67,486 out of 8,379,074 ( 0.8%) are on Y
+          38 out of 8,379,074 ( 0.0%) are on M
++ for catalog_filename in human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz mukamel_VNTR_catalog.bed.gz vamos_catalog.v2.1.bed.gz hg38_ver17.variant_catalog.json adotto_tr_catalog_v1.2.bed.gz
 + echo Processing mukamel_VNTR_catalog.bed.gz
 Processing mukamel_VNTR_catalog.bed.gz
-++ echo mukamel_VNTR_catalog.bed.gz
 ++ sed 's/.bed.gz$//'
+++ echo mukamel_VNTR_catalog.bed.gz
 ++ sed 's/.variant_catalog.json$//'
 + current_catalog_output_prefix=mukamel_VNTR_catalog
 + python3 -m str_analysis.annotate_and_filter_str_catalog -r /Users/weisburd/project1/ref/GRCh38/hg38.fa --skip-gene-annotations --skip-mappability-annotations --skip-disease-loci-annotations --min-motif-size 2 --max-motif-size 1000 --output-path mukamel_VNTR_catalog.annotated_and_filtered.json --verbose mukamel_VNTR_catalog.bed.gz
@@ -877,7 +1053,7 @@ Chromsomes:
      167,667 out of 3,227,921 ( 5.2%) are on X
       29,107 out of 3,227,921 ( 0.9%) are on Y
           14 out of 3,227,921 ( 0.0%) are on M
-+ for catalog_filename in mukamel_VNTR_catalog.bed.gz vamos_catalog.v2.1.bed.gz hg38_ver17.variant_catalog.json adotto_tr_catalog_v1.2.bed.gz
++ for catalog_filename in human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz mukamel_VNTR_catalog.bed.gz vamos_catalog.v2.1.bed.gz hg38_ver17.variant_catalog.json adotto_tr_catalog_v1.2.bed.gz
 + echo Processing vamos_catalog.v2.1.bed.gz
 Processing vamos_catalog.v2.1.bed.gz
 ++ echo vamos_catalog.v2.1.bed.gz
@@ -2381,7 +2557,7 @@ Chromsomes:
      193,257 out of 3,816,522 ( 5.1%) are on X
       34,203 out of 3,816,522 ( 0.9%) are on Y
           14 out of 3,816,522 ( 0.0%) are on M
-+ for catalog_filename in mukamel_VNTR_catalog.bed.gz vamos_catalog.v2.1.bed.gz hg38_ver17.variant_catalog.json adotto_tr_catalog_v1.2.bed.gz
++ for catalog_filename in human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz mukamel_VNTR_catalog.bed.gz vamos_catalog.v2.1.bed.gz hg38_ver17.variant_catalog.json adotto_tr_catalog_v1.2.bed.gz
 + echo Processing hg38_ver17.variant_catalog.json
 Processing hg38_ver17.variant_catalog.json
 ++ echo hg38_ver17.variant_catalog.json
@@ -2436,7 +2612,7 @@ Stats for hg38_ver17.annotated_and_filtered.json:
       851,598 out of    851,598 (100.0%) repeat interval size is an integer multiple of the motif size (aka. trimmed)
             0 out of    851,598 (  0.0%) repeat intervals are homopolymers
            16 out of    851,598 (  0.0%) repeat intervals overlap each other by at least two motif lengths
-Examples of overlapping repeats: chr11:2171085-2171113, chr9:27573523-27573541, chr5:123775555-123775599, chr2:1489650-1489682, chr11:2171087-2171115, chr15:96831011-96831036, chr20:2652732-2652756, chr2:1489652-1489684, chr20:2652733-2652757, chr9:27573528-27573546
+Examples of overlapping repeats: chr2:1489650-1489682, chr20:2652732-2652756, chr9:27573523-27573541, chr15:96831014-96831039, chr5:123775552-123775596, chr15:96831011-96831036, chr11:2171087-2171115, chr5:123775555-123775599, chr9:27573528-27573546, chr2:1489652-1489684
 
 Ranges:
    Motif size range: 2-20bp
@@ -2517,7 +2693,7 @@ Chromsomes:
      167,667 out of 3,227,828 ( 5.2%) are on X
       29,107 out of 3,227,828 ( 0.9%) are on Y
           14 out of 3,227,828 ( 0.0%) are on M
-+ for catalog_filename in mukamel_VNTR_catalog.bed.gz vamos_catalog.v2.1.bed.gz hg38_ver17.variant_catalog.json adotto_tr_catalog_v1.2.bed.gz
++ for catalog_filename in human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz mukamel_VNTR_catalog.bed.gz vamos_catalog.v2.1.bed.gz hg38_ver17.variant_catalog.json adotto_tr_catalog_v1.2.bed.gz
 + echo Processing adotto_tr_catalog_v1.2.bed.gz
 Processing adotto_tr_catalog_v1.2.bed.gz
 ++ echo adotto_tr_catalog_v1.2.bed.gz
@@ -2713,7 +2889,7 @@ Stats for adotto_tr_catalog_v1.2.annotated_and_filtered.json:
       926,416 out of  2,917,225 ( 31.8%) repeat interval size is an integer multiple of the motif size (aka. trimmed)
             0 out of  2,917,225 (  0.0%) repeat intervals are homopolymers
        26,599 out of  2,917,225 (  0.9%) repeat intervals overlap each other by at least two motif lengths
-Examples of overlapping repeats: chr7:2593081-2593118, chr4:6208261-6208280, chr4:94612216-94612254, chrX:40700148-40700178, chr4:145846476-145846524, chr14:43214982-43214997, chr16:15733534-15733558, chr2:202643701-202643725, chr3:177091069-177091082, chr4:112549351-112549392
+Examples of overlapping repeats: chrX:120796960-120796988, chr3:195929109-195929154, chr1:240377809-240377907, chrX:1375432-1375450, chr5:167713596-167713650, chr18:22069065-22069078, chr2:87393086-87393269, chr1:181053066-181053097, chr6:118187016-118187045, chr9:128080232-128080272
 
 Ranges:
    Motif size range: 2-495bp
@@ -2794,5 +2970,5 @@ Chromsomes:
      236,617 out of 5,054,868 ( 4.7%) are on X
       39,818 out of 5,054,868 ( 0.8%) are on Y
           14 out of 5,054,868 ( 0.0%) are on M
-+ echo 'Done.  Total time: 1hrs 54min 29sec'
-Done.  Total time: 1hrs 54min 29sec
++ echo 'Done.  Total time: 2hrs 36min 37sec'
+Done.  Total time: 2hrs 36min 37sec

--- a/all_steps.merge_and_annotate_loci.sh
+++ b/all_steps.merge_and_annotate_loci.sh
@@ -23,8 +23,9 @@ then
     exit 1
 fi
 
-mkdir -p results
-cd results
+OUTPUT_DIR=results__$(date +%F)
+mkdir -p ${OUTPUT_DIR}
+cd ${OUTPUT_DIR}
 
 
 SECONDS=0
@@ -180,14 +181,17 @@ python3 -m str_analysis.compute_catalog_stats --verbose ${OUTPUT_PREFIX}.merged_
 mkdir -p comparisons
 cd comparisons
 
+wget -qnc https://zenodo.org/records/13178746/files/human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.bed.gz
 wget -qnc https://s3.amazonaws.com/gangstr/hg38/genomewide/hg38_ver17.bed.gz
 wget -qnc https://storage.googleapis.com/str-truth-set/hg38/ref/other/adotto_tr_catalog_v1.2.bed.gz
 wget -qnc https://storage.googleapis.com/str-truth-set/hg38/ref/other/mukamel_VNTR_catalog.bed.gz
 wget -qnc https://storage.googleapis.com/str-truth-set/hg38/ref/other/vamos_catalog.v2.1.bed.gz
 
+python3 -u -m str_analysis.convert_trgt_catalog_to_expansion_hunter_catalog -r ${REFERENCE_FASTA_PATH} human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.bed.gz -o human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz 
+
 python3 -u -m str_analysis.convert_gangstr_spec_to_expansion_hunter_variant_catalog --verbose hg38_ver17.bed.gz
 
-for catalog_filename in mukamel_VNTR_catalog.bed.gz  vamos_catalog.v2.1.bed.gz hg38_ver17.variant_catalog.json    adotto_tr_catalog_v1.2.bed.gz
+for catalog_filename in human_GRCh38_no_alt_analysis_set.platinumTRs-v1.0.trgt.json.gz  mukamel_VNTR_catalog.bed.gz  vamos_catalog.v2.1.bed.gz hg38_ver17.variant_catalog.json    adotto_tr_catalog_v1.2.bed.gz
 do
     echo Processing ${catalog_filename}
     current_catalog_output_prefix=$(echo ${catalog_filename} | sed 's/.bed.gz$//' | sed 's/.variant_catalog.json$//')

--- a/scripts/add_variation_cluster_annotations_to_catalog.py
+++ b/scripts/add_variation_cluster_annotations_to_catalog.py
@@ -18,7 +18,7 @@ def main():
 		args.output_json_path = args.catalog_json_path.replace(".json", ".with_variation_clusters.json")
 
 	# parse the variation clusters bed file
-	locus_id_to_variation_cluster_id = {}
+	#locus_id_to_variation_cluster_id = {}
 	locus_id_to_variation_cluster_interval = {}
 
 	if args.verbose:
@@ -44,11 +44,11 @@ def main():
 				info_fields_dict[key] = value
 			for locus_id in info_fields_dict["ID"].split(","):
 				locus_id_to_variation_cluster_interval[locus_id] = f"{chrom}:{start_0based}-{end_1based}"
-				locus_id_to_variation_cluster_id[locus_id] = info_fields_dict["ID"]
+				#locus_id_to_variation_cluster_id[locus_id] = info_fields_dict["ID"]
 
-	total_variation_clusters = len(locus_id_to_variation_cluster_id)
+	total_variation_clusters = len(locus_id_to_variation_cluster_interval)
 	if args.verbose:
-		print(f"Parsed {len(locus_id_to_variation_cluster_id):,d} variation clusters from {args.variation_clusters_bed_path}")
+		print(f"Parsed {len(locus_id_to_variation_cluster_interval):,d} variation clusters from {args.variation_clusters_bed_path}")
 
 	fopen = gzip.open if args.catalog_json_path.endswith("gz") else open
 	with fopen(args.catalog_json_path, "rt") as f:
@@ -68,9 +68,9 @@ def main():
 					#	print(f"WARNING: locus_id {locus_id} not found in variation cluster catalog")
 					continue
 
-				record["VariationClusterId"] = locus_id_to_variation_cluster_id[locus_id]
-				record["VariationClusterInterval"] = locus_id_to_variation_cluster_interval[locus_id]
-				del locus_id_to_variation_cluster_id[locus_id]
+				#record["VariationClusterId"] = locus_id_to_variation_cluster_id[locus_id]
+				record["VariationCluster"] = locus_id_to_variation_cluster_interval[locus_id]
+				#del locus_id_to_variation_cluster_id[locus_id]
 				del locus_id_to_variation_cluster_interval[locus_id]
 
 				output_counter += 1
@@ -84,8 +84,8 @@ def main():
 	if args.verbose:
 		print(f"Skipped {skipped_counter:,d} out of {input_counter:,d} ({skipped_counter/input_counter:.1%}) records "
 			  f"from {args.catalog_json_path}")
-		print(f"Used {total_variation_clusters - len(locus_id_to_variation_cluster_id):,d} out of {total_variation_clusters:,d} "
-			  f"({(total_variation_clusters - len(locus_id_to_variation_cluster_id))/total_variation_clusters:.1%}) of "
+		print(f"Used {total_variation_clusters - len(locus_id_to_variation_cluster_interval):,d} out of {total_variation_clusters:,d} "
+			  f"({(total_variation_clusters - len(locus_id_to_variation_cluster_interval))/total_variation_clusters:.1%}) of "
 			  f"variation clusters from {args.variation_clusters_bed_path}")
 		print(f"Wrote {output_counter:,d} out of {input_counter:,d} ({output_counter/input_counter:.1%}) records "
 			  f"to {args.output_json_path}")

--- a/scripts/add_variation_cluster_annotations_to_catalog.py
+++ b/scripts/add_variation_cluster_annotations_to_catalog.py
@@ -1,0 +1,96 @@
+import argparse
+import gzip
+import ijson
+import simplejson as json
+import tqdm
+
+
+def main():
+	parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+	parser.add_argument("--verbose", action="store_true")
+	parser.add_argument("--show-progress-bar", action="store_true", help="Show a progress bar")
+	parser.add_argument("--output-json-path", help="Path of the output JSON file")
+	parser.add_argument("variation_clusters_bed_path", help="Path of the variation clusters BED file")
+	parser.add_argument("catalog_json_path", help="Path of the JSON catalog to annotate")
+	args = parser.parse_args()
+
+	if not args.output_json_path:
+		args.output_json_path = args.catalog_json_path.replace(".json", ".with_variation_clusters.json")
+
+	# parse the variation clusters bed file
+	locus_id_to_variation_cluster_id = {}
+	locus_id_to_variation_cluster_interval = {}
+
+	if args.verbose:
+		print(f"Parsing {args.variation_clusters_bed_path}")
+	fopen = gzip.open if args.variation_clusters_bed_path.endswith("gz") else open
+	with fopen(args.variation_clusters_bed_path, "rt") as f:
+		if args.show_progress_bar:
+			f = tqdm.tqdm(f, unit=" records", unit_scale=True)
+		for line in f:
+			fields = line.strip("\n").split("\t")
+			chrom = fields[0]
+			start_0based = int(fields[1])
+			end_1based = int(fields[2])
+			info_fields = fields[3]
+
+			info_fields_dict = {}
+			for key_value in info_fields.split(";"):
+				key_value = key_value.split("=")
+				if len(key_value) != 2:
+					print(f"WARNING: skipping invalid key-value pair '{key_value}' in line {fields}")
+					continue
+				key, value = key_value
+				info_fields_dict[key] = value
+			for locus_id in info_fields_dict["ID"].split(","):
+				locus_id_to_variation_cluster_interval[locus_id] = f"{chrom}:{start_0based}-{end_1based}"
+				locus_id_to_variation_cluster_id[locus_id] = info_fields_dict["ID"]
+
+	total_variation_clusters = len(locus_id_to_variation_cluster_id)
+	if args.verbose:
+		print(f"Parsed {len(locus_id_to_variation_cluster_id):,d} variation clusters from {args.variation_clusters_bed_path}")
+
+	fopen = gzip.open if args.catalog_json_path.endswith("gz") else open
+	with fopen(args.catalog_json_path, "rt") as f:
+		f2open = gzip.open if args.output_json_path.endswith("gz") else open
+		with f2open(args.output_json_path, "wt") as f2:
+			input_counter = skipped_counter = output_counter = 0
+			iterator = ijson.items(f, "item")
+			if args.show_progress_bar:
+				iterator = tqdm.tqdm(iterator, unit=" records", unit_scale=True)
+			f2.write("[")
+			for i, record in enumerate(iterator):
+				locus_id = record["LocusId"]
+				input_counter += 1
+				if locus_id not in locus_id_to_variation_cluster_interval:
+					skipped_counter += 1
+					#if args.verbose:
+					#	print(f"WARNING: locus_id {locus_id} not found in variation cluster catalog")
+					continue
+
+				record["VariationClusterId"] = locus_id_to_variation_cluster_id[locus_id]
+				record["VariationClusterInterval"] = locus_id_to_variation_cluster_interval[locus_id]
+				del locus_id_to_variation_cluster_id[locus_id]
+				del locus_id_to_variation_cluster_interval[locus_id]
+
+				output_counter += 1
+				if i > 0:
+					f2.write(",")
+				f2.write(json.dumps(record, f2, use_decimal=True, indent=4))
+				f2.write("\n")
+
+			f2.write("]")
+
+	if args.verbose:
+		print(f"Skipped {skipped_counter:,d} out of {input_counter:,d} ({skipped_counter/input_counter:.1%}) records "
+			  f"from {args.catalog_json_path}")
+		print(f"Used {total_variation_clusters - len(locus_id_to_variation_cluster_id):,d} out of {total_variation_clusters:,d} "
+			  f"({(total_variation_clusters - len(locus_id_to_variation_cluster_id))/total_variation_clusters:.1%}) of "
+			  f"variation clusters from {args.variation_clusters_bed_path}")
+		print(f"Wrote {output_counter:,d} out of {input_counter:,d} ({output_counter/input_counter:.1%}) records "
+			  f"to {args.output_json_path}")
+
+
+if __name__ == "__main__":
+	main()
+


### PR DESCRIPTION
Run log now contains stats for the Platinum TRGT catalog. 

Also, added script for adding variation clusters to the catalog

Example command:

```
python3 scripts/add_variation_cluster_annotations_to_catalog.py \
--verbose --show-progress-bar \
vcs_merged.bed.gz \
repeat_catalog.3x_and_9bp.2_to_1000bp_motifs.hg38.merged_and_annotated.json.gz 
```